### PR TITLE
Update publisher api call

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,8 @@
             "program": "${workspaceRoot}/server/server.js",
             "env": {
                 "NODE_ENV": "sandbox",
-                "API_TYPE": "public"
+                "API_TYPE": "public",
+                // "RUN_JOBS": "run" // un-comment to run boot jobs
             },
             "restart": true,
             "console": "integratedTerminal",

--- a/server/boot/jobs/registry.js
+++ b/server/boot/jobs/registry.js
@@ -10,18 +10,28 @@ const Version = app.models['version'];
 // TODO: rename googleStorageConfig to more generic config identifier
 const googleStorageConfig = require('../../../common/config/google-storage');
 
+const getPaginatedRequest = async ({ offset, limit }, response = []) => {
+  try {
+    let result = await axios.get(
+      googleStorageConfig.registry.api_url 
+      +'/action/organization_list'
+      + `?offset=${offset}&limit=${limit}`
+    );
+    if (result.data.success && result.data.result.length !== 0) {
+          response = response.concat(result.data.result);
+          offset += limit;
+          return await getPaginatedRequest( { offset, limit }, response)
+    } else {
+      return response
+    }
+  } catch (error) {
+    console.error('IATI Registry returned other than 200 when getting the list of orgs - specifically ' + error.message);           
+  }
+}
+
 const getPublishers = async () => {
   console.log('registry sync starting');
-  const organisationListResponse =
-    await axios.get(googleStorageConfig.registry.api_url + `/action/organization_list`);
-
-  if (organisationListResponse.status != 200) {
-    console.error('IATI Registry returned other than 200 when getting the list of orgs - specifically ' + organisationListResponse.status);
-    return;
-  }
-
-  const organisationList = organisationListResponse.data.result;
-
+  const organisationList = await getPaginatedRequest({ offset: 0, limit: 1000})
   let existing = await Publisher.find({},{slug:1,_id:0});
 
   for (let n=0; n<existing.length; n++) {
@@ -77,7 +87,7 @@ const getPublishers = async () => {
 
   console.log('registry sync completed');
 };
-
+getPublishers();
 const job = schedule.scheduleJob(googleStorageConfig.registry.cronschedule, () => {
   getPublishers();
 });


### PR DESCRIPTION
## Problem Summary
Previously the registry endpoint that returns a list of publishing organisations (https://iatiregistry.org/api/3/action/organization_list) returned all active organisations. It has been changed (inline with CKAN best practices) to only return a max of 1000 results, and make use of `offset` and `limit` query parameters to paginate the output.

## Changes
This PR updates the API call that retrieves the list of publishers from the registry to make use of the `offset` and `limit` query parameters and iterate on the endpoint to receive all the results.

## Details

For example if there are 2500 publishers:
- 1st API call with GET parameters - limit=1000&offset=0
- 2nd call: API with GET parameters - limit=1000&offset=1000
- 3rd call: API with GET parameters - limit=1000&offset=2000

By the end of the 3rd API call, all publishers will be fetched. 
